### PR TITLE
moon note機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,8 @@ end
 
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
-  gem "web-console"
+  gem "better_errors"
+  gem "binding_of_caller"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,8 +80,13 @@ GEM
     bcrypt_pbkdf (1.1.1-arm64-darwin)
     bcrypt_pbkdf (1.1.1-x86_64-darwin)
     benchmark (0.4.1)
+    better_errors (2.10.1)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
+      rouge (>= 1.0.0)
     bigdecimal (3.3.1)
-    bindex (0.8.1)
+    binding_of_caller (1.0.1)
+      debug_inspector (>= 1.2.0)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
     brakeman (7.1.1)
@@ -107,6 +112,7 @@ GEM
     debug (1.11.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    debug_inspector (1.2.0)
     diff-lcs (1.6.2)
     dotenv (3.1.8)
     dotenv-rails (3.1.8)
@@ -328,6 +334,7 @@ GEM
     reline (0.6.2)
       io-console (~> 0.5)
     rexml (3.4.4)
+    rouge (4.6.1)
     rspec-core (3.13.6)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
@@ -446,11 +453,6 @@ GEM
     uri (1.0.4)
     useragent (0.16.11)
     version_gem (1.1.9)
-    web-console (4.2.1)
-      actionview (>= 6.0.0)
-      activemodel (>= 6.0.0)
-      bindex (>= 0.4.0)
-      railties (>= 6.0.0)
     webmock (3.26.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -476,6 +478,8 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  better_errors
+  binding_of_caller
   bootsnap
   brakeman
   capybara
@@ -509,7 +513,6 @@ DEPENDENCIES
   thruster
   turbo-rails
   tzinfo-data
-  web-console
   webmock
 
 BUNDLED WITH

--- a/app/controllers/moon_notes_controller.rb
+++ b/app/controllers/moon_notes_controller.rb
@@ -1,7 +1,44 @@
 class MoonNotesController < ApplicationController
+  before_action :require_login
+
   def new
+    @moon_note = current_user.moon_notes.build
+    data = MoonApiService.fetch(Date.today)
+    if data[:event].blank?
+      redirect_to dashboard_path, alert: "今日のMoon Noteはありません。"
+    else
+      @moon_note.moon_phase = data[:event]
+      @moon_phase_name = data[:moon_phase_name]
+      @moon_phase_emoji = data[:moon_phase_emoji]
+      @moon_age = data[:moon_age]
+
+    theme = MoonNoteThemeService.for(data[:event])
+      @moon_theme = theme[:title]
+      @moon_theme_description = theme[:description]
+      flash.now[:notice] = "今日は#{data[:moon_phase_name]}です。Moon Noteを作成しましょう！"
+      render :new
+    end
   end
 
   def create
+    data = MoonApiService.fetch(Date.today)
+    return redirect_to dashboard_path if data.nil? || data[:event].blank?
+    return redirect_to dashboard_path, alert: "今日のMoon Noteは作成済みです" if current_user.moon_notes.exists?(date: data[:date])
+    @moon_note = current_user.moon_notes.build(moon_note_params)
+    @moon_note.moon_phase = data[:event]
+    @moon_note.date = data[:date]
+    @moon_note.moon_age = data[:moon_age]
+    if @moon_note.save
+      redirect_to dashboard_path, notice: "Moon Noteを保存しました"
+    else
+      flash.now[:alert] = "Moon Noteの保存に失敗しました"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def moon_note_params
+    params.require(:moon_note).permit(:content)
   end
 end

--- a/app/models/moon_note.rb
+++ b/app/models/moon_note.rb
@@ -1,0 +1,15 @@
+class MoonNote < ApplicationRecord
+  belongs_to :user
+
+  validates :date, presence: true
+  validates :moon_age, presence: true
+  validates :moon_phase, presence: true
+  validates :content, presence: true, length: { maximum: 1000 }
+
+  enum :moon_phase, {
+    new_moon: 0,
+    first_quarter_moon: 1,
+    full_moon: 2,
+    last_quarter_moon: 3
+  }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_many :daily_notes, dependent: :destroy
+  has_many :moon_notes, dependent: :destroy
   validates :line_user_id, presence: true, uniqueness: true
   validates :account_registered, inclusion: { in: [ true, false ] }
 

--- a/app/services/moon_note_theme_service.rb
+++ b/app/services/moon_note_theme_service.rb
@@ -1,0 +1,24 @@
+class MoonNoteThemeService
+  THEMES = {
+    new_moon: {
+      title: "新しい始まり",
+      description: "新月はスタートのタイミング。なりたい姿をイメージしましょう"
+    },
+    first_quarter_moon: {
+      title: "吸収と行動",
+      description: "上弦の月は行動力が高まるとき。願いを叶えるために取り入れたいことはありますか？"
+    },
+    full_moon: {
+      title: "振り返りと感謝",
+      description: "満月は達成や完了のエネルギーが高まります。感謝とともに振り返りましょう。"
+    },
+    last_quarter_moon: {
+      title: "手放しと浄化",
+      description: "下弦の月は不要なものをリセットしていくタイミング。手放したいことは何ですか？"
+    }
+  }
+
+  def self.for(event)
+    THEMES[event] || { title: "", description: "" }
+  end
+end

--- a/app/views/moon_notes/new.html.erb
+++ b/app/views/moon_notes/new.html.erb
@@ -1,4 +1,57 @@
-<div>
-  <h1 class="font-bold text-4xl">MoonNotes#new</h1>
-  <p>Find me in app/views/moon_notes/new.html.erb</p>
-</div>
+<section class="relative min-h-screen w-full flex flex-col items-center justify-start px-4 py-12">
+
+  <div class="absolute inset-0 bg-gradient-to-b from-[#1a1833] via-[#1c1a40] to-[#1a1a2d] opacity-90 pointer-events-none"></div>
+
+  <div class="relative z-10 w-full max-w-2xl space-y-8">
+
+    <div class="text-center space-y-3">
+      <div class="text-5xl font-display text-primary">
+        <%= @moon_phase_emoji %>
+      </div>
+      <h1 class="text-3xl font-bold text-primary-content">
+        <%= @moon_phase_name %> の Moon Note
+      </h1>
+      <p class="text-base text-base-content/80">
+      今日の月に合わせたテーマを用意しました。今のあなたの気持ちを書き留めてみましょう。
+      </p>
+    </div>
+
+    <div class="card bg-base-200/60 backdrop-blur-xl shadow-xl border border-base-100/20">
+      <div class="card-body space-y-4 text-center">
+        <h2 class="card-title text-xl font-semibold text-primary">
+          今回のテーマ：<%= @moon_theme %>
+        </h2>
+        <p class="text-base text-base-content/80 leading-relaxed">
+          <%= @moon_theme_description %>
+        </p>
+      </div>
+    </div>
+
+    <%= form_with model: @moon_note, local: true do |f| %>
+
+      <div class="card bg-base-100/70 backdrop-blur-xl shadow-lg border border-base-content/10">
+        <div class="card-body space-y-6">
+
+          <div>
+            <label class="label">
+              <span class="label-text text-base font-medium">あなたの Moon Note</span>
+            </label>
+
+            <%= f.text_area :content,
+                rows: 8,
+                class: "textarea textarea-bordered textarea-lg w-full bg-base-200/60 backdrop-blur text-base-content",
+                placeholder: "月のテーマに照らして、思っていること・願い・手放したいものなどを書いてみてください…" %>
+          </div>
+
+        </div>
+      </div>
+
+      <div class="mt-6 flex justify-center">
+        <%= f.submit "保存する",
+            class: "btn btn-primary px-8 py-2 rounded-xl shadow-md" %>
+      </div>
+
+    <% end %>
+
+  </div>
+</section>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,7 @@
 require "active_support/core_ext/integer/time"
+if Rails.env.development?
+  BetterErrors::Middleware.allow_ip! "0.0.0.0/0"
+end
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -24,6 +27,7 @@ Rails.application.configure do
   else
     config.action_controller.perform_caching = false
   end
+
 
   # Change to :null_store to avoid any caching.
   config.cache_store = :memory_store

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,14 +2,20 @@ ja:
   activerecord:
     models:
       daily_note: 日記
+      moon_note: ムーンノート
 
     attributes:
       daily_note:
         condition_score: 体調
         mood_score: 気分
-        date: 日付
+        date: 今日
         memo: メモ
-
+      moon_note:
+        moon_phase:
+          new_moon: 新月
+          first_quarter_moon: 上弦の月
+          full_moon: 満月
+          first_quarter_moon: 下弦の月
     errors:
       blank: "を入力してください"
       taken: "は既に記入済みです"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   resource :account_name, only: [ :edit, :update ]
   resources :users, only: [ :show, :edit, :update ]
   resources :daily_notes, only: [ :index, :create, :edit, :update, :destroy ]
+  resources :moon_notes, only: [ :new, :create ]
 
   get "up" => "rails/health#show", as: :rails_health_check
 

--- a/db/migrate/20251115120610_create_moon_notes.rb
+++ b/db/migrate/20251115120610_create_moon_notes.rb
@@ -1,0 +1,16 @@
+class CreateMoonNotes < ActiveRecord::Migration[8.0]
+  def change
+    create_table :moon_notes do |t|
+      t.references :user, null: false, foreign_key: true
+
+      t.date :date, null: false
+      t.float :moon_age, null: false
+      t.integer :moon_phase, null: false
+      t.text :content
+
+      t.timestamps
+    end
+
+    add_index :moon_notes, [ :user_id, :date ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_07_082900) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_15_120610) do
   create_table "daily_notes", force: :cascade do |t|
     t.integer "user_id", null: false
     t.date "date", null: false
@@ -28,6 +28,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_07_082900) do
     t.index ["user_id"], name: "index_daily_notes_on_user_id"
   end
 
+  create_table "moon_notes", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.date "date", null: false
+    t.float "moon_age", null: false
+    t.integer "moon_phase", null: false
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "date"], name: "index_moon_notes_on_user_id_and_date", unique: true
+    t.index ["user_id"], name: "index_moon_notes_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "line_user_id", null: false
     t.string "name"
@@ -38,4 +50,5 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_07_082900) do
   end
 
   add_foreign_key "daily_notes", "users"
+  add_foreign_key "moon_notes", "users"
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :user do
     sequence(:line_user_id) { |n| "U#{n.to_s.rjust(16, '0')}" }
     name { nil }
-    account_registered { false }
 
     trait :with_account_name do
       name { "テストユーザー" }
@@ -10,7 +9,6 @@ FactoryBot.define do
 
     trait :registered do
       name { "登録済みユーザー" }
-      account_registered { true }
     end
   end
 end

--- a/spec/models/moon_note_spec.rb
+++ b/spec/models/moon_note_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "Moon Note", type: :model do
+  let(:user) { create(:user) }
+
+  context "バリデーション" do
+    it "正常系: 正しく入力されているとき、Moon Noteが保存される" do
+      moon_note = MoonNote.new(
+        user: user,
+        date: Date.today,
+        moon_phase: "full_moon",
+        moon_age: 14.3,
+        content: "満月で気分が高まった。"
+      )
+      expect(moon_note).to be_valid
+    end
+
+    it "異常系: contentが未入力のとき、Moon Noteが保存されない" do
+      moon_note = MoonNote.new(
+        user: user,
+        date: Date.today,
+        moon_phase: "new_moon",
+        moon_age: 0.0,
+        content: nil
+      )
+      expect(moon_note).to be_invalid
+    end
+  end
+end

--- a/spec/system/moon_note_spec.rb
+++ b/spec/system/moon_note_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe "Moon Note作成フロー", type: :system do
+  let(:user) { create(:user, :registered) }
+
+  before { sign_in_as(user) }
+
+  context "今日は満月" do
+    before do
+      allow(MoonApiService).to receive(:fetch).and_return(
+        event: :full_moon,
+        moon_phase_name: "満月",
+        moon_phase_emoji: "🌕",
+        moon_age: 14.3,
+        date: Date.today
+      )
+    end
+
+    it "moon note作成画面に遷移できる" do
+      visit new_moon_note_path
+      expect(page).to have_content("今日は満月です。Moon Noteを作成しましょう！")
+      expect(page).to have_button("保存する")
+    end
+
+    it "moon noteを正しく保存できる" do
+      visit new_moon_note_path
+      fill_in "moon_note_content", with: "早起きが習慣になってきた。"
+      click_button "保存する"
+
+      expect(page).to have_content("Moon Noteを保存しました")
+      expect(MoonNote.count).to eq(1)
+      expect(MoonNote.last.moon_phase).to eq("full_moon")
+    end
+  end
+
+  context "今日はどの月相にもあたらない" do
+    before do
+      allow(MoonApiService).to receive(:fetch).and_return(
+        event: nil,
+        moon_phase_name: "その他",
+        moon_phase_emoji: "",
+        moon_age: 12.0,
+        date: Date.today
+      )
+    end
+
+    it "moon note作成画面に遷移できずダッシュボードにリダイレクトされる" do
+      visit new_moon_note_path
+      expect(page).to have_current_path(dashboard_path)
+      expect(page).to have_content("今日のMoon Noteはありません。")
+    end
+  end
+end


### PR DESCRIPTION
## 概要
新月、満月、上弦の月、下弦の月の日だけ投稿できるmoon note機能を追加した。
それぞれの月相に合わせたテーマについて、自分の思いを残せる。

## 変更内容
- `moon_note_controller`にて、new及びcreateアクションを追加
- `moon_api_service.rb`にて、`event`を返すようなロジックを追加
これによって、特定の月相のときのみ投稿できるようにした。
- テストを書いた

## スクショ（画面やログの一部）
[![Image from Gyazo](https://i.gyazo.com/5e63f0d555313f0e650da593f1682f1a.png)](https://gyazo.com/5e63f0d555313f0e650da593f1682f1a)

## 補足
- UIはもう少しかわいくしたいかも

## 苦労したことなどあれば
- enumの書き方を間違えていた
- 月相によって投稿できる/できないを実装するところ
