### PR TITLE
ログアウト機能追加

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,8 +1,7 @@
 class HomeController < ApplicationController
   def index
-    Rails.logger.info("Moon value: #{@moon.inspect}")
     @moon = MoonApiService.fetch(Date.today)
-    redirect_to dashboard_path if current_user
+    redirect_to dashboard_path if current_user.present?
   end
 
   def dashboard; end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,6 @@
+class SessionsController < ApplicationController
+  def destroy
+    reset_session
+    redirect_to root_path, notice: "ログアウトしました"
+  end
+end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -59,18 +59,24 @@
     </ul>
   </div>
 
-    <div class="dropdown dropdown-end">
-      <label tabindex="0" class="btn btn-ghost px-2 text-2xl cursor-pointer">⋯</label>
-      <ul tabindex="0"
-          class="menu dropdown-content bg-base-100 rounded-box w-52 mt-3 p-2 shadow">
-        <li><%= link_to "月めぐるノートとは？", page_path("about") %></li>
-        <li><%= link_to "使い方", page_path("howto") %></li>
-        <li><%= link_to "お問い合わせ", page_path("contact") %></li>
-        <li><%= link_to "リリースノート", page_path("releases") %></li>
-        <li><%= link_to "フィードバック", page_path("feedback") %></li>
-      </ul>
-    </div>
+  <div class="dropdown dropdown-end">
+    <label tabindex="0" class="btn btn-ghost px-2 text-2xl cursor-pointer">⋯</label>
+    <ul tabindex="0"
+        class="menu dropdown-content bg-base-100 rounded-box w-52 mt-3 p-2 shadow">
+      <li><%= link_to "月めぐるノートとは？", page_path("about") %></li>
+      <li><%= link_to "使い方", page_path("howto") %></li>
+      <li><%= link_to "お問い合わせ", page_path("contact") %></li>
+      <li><%= link_to "リリースノート", page_path("releases") %></li>
+      <li><%= link_to "フィードバック", page_path("feedback") %></li>
+    </ul>
+  </div>
 
+  <div class="navbar-end">
+    <% if current_user %>
+      <%= link_to "ログアウト", session_path, data: { turbo_method: :delete }, class: "btn btn-secondary" %>
+    <% else %>
+      <%= link_to "ログイン", line_login_api_login_path, class: "btn btn-primary" %>
+    <% end %>
   </div>
 
 </header>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   resources :users, only: [ :show, :edit, :update ]
   resources :daily_notes, only: [ :index, :new, :create, :edit, :update, :destroy ]
   resources :moon_notes, only: [ :index, :new, :create, :edit, :update, :destroy ]
+  resource :session, only: [ :destroy ]
 
   get "up" => "rails/health#show", as: :rails_health_check
 

--- a/spec/support/line_login_helper.rb
+++ b/spec/support/line_login_helper.rb
@@ -1,0 +1,19 @@
+module LineAuthStub
+  def stub_line_auth(line_user_id: "U1234567890abcdef")
+    # LineLoginApiController#login で生成される state と同じ値をモック
+    allow(SecureRandom).to receive(:urlsafe_base64).and_return("dummy_state")
+
+    allow_any_instance_of(LineAuth::AuthorizationService)
+      .to receive(:authorization_url)
+      .and_return("/line_login_api/callback?code=dummy&state=dummy_state")
+
+    allow_any_instance_of(LineAuth::TokenService)
+      .to receive(:exchange_code_for_token)
+      .and_return("dummy_id_token")
+
+    allow_any_instance_of(LineAuth::IdTokenVerifier)
+      .to receive(:verify_and_get_user_id)
+      .with("dummy_id_token")
+      .and_return(line_user_id)
+  end
+end

--- a/spec/system/session_spec.rb
+++ b/spec/system/session_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "セッション管理", type: :system do
+  include LineAuthStub
+
+  before do
+    driven_by(:rack_test)
+  end
+
+  it "LINEログインしてからログアウトできる" do
+    User.create!(line_user_id: "U1234567890abcdef", name: "テストユーザー", account_registered: true)
+    stub_line_auth
+
+    visit root_path
+
+    click_on "ログイン"
+
+    expect(page).to have_current_path(dashboard_path)
+
+    click_on "ログアウト"
+    expect(page).to have_current_path(root_path)
+  end
+end


### PR DESCRIPTION
## 概要
ログアウトボタンをヘッダーに設置し、ログアウトできるようにする

## 対応issue
#77 

## 変更内容
- `session_controller.rb`にlogoutアクションを追加
- ヘッダーにログアウトボタンを設置
ログイン前はログインボタンとして機能するようにした
- テストのリファクタリング

## スクショ（画面やログの一部）
[![Image from Gyazo](https://i.gyazo.com/8194d63537ed1d20318f337f4bbcbf85.png)](https://gyazo.com/8194d63537ed1d20318f337f4bbcbf85)

## 補足
-

## 苦労したことなどあれば
- ログアウト自体は簡単だったが、テストのリファクタリングが大変だった
