### PR TITLE
ダークモードをなくした

### DIFF
--- a/app/assets/tailwind/daisyui.mjs
+++ b/app/assets/tailwind/daisyui.mjs
@@ -50,7 +50,7 @@ var pluginOptionsHandler = (() => {
     const {
       logs = true,
       root = ":root",
-      themes = ["light --default", "dark --prefersdark"],
+      themes = ["light --default"],
       include,
       exclude,
       prefix = ""


### PR DESCRIPTION
## 概要
ダークモードになると変な色になるのをやめた

## 対応issue
#138 

## 変更内容
- daisyUIでの設定のダークモードを適用するコードを消した


## スクショ（画面やログの一部）
変更前
[![Image from Gyazo](https://i.gyazo.com/25e952e73d26905b2c9ca018d41b38bd.png)](https://gyazo.com/25e952e73d26905b2c9ca018d41b38bd)

変更後
[![Image from Gyazo](https://i.gyazo.com/654730746ea22c03a915006392e8c34c.png)](https://gyazo.com/654730746ea22c03a915006392e8c34c)

## ここではやらないこと

- [ ]

## 苦労したことなどあれば

-
