### PR TITLE
ダッシュボードが表示されないのを修正

### DIFF
--- a/app/javascript/pages/dashboard.jsx
+++ b/app/javascript/pages/dashboard.jsx
@@ -2,13 +2,19 @@ import React from "react"
 import { createRoot } from "react-dom/client"
 import Dashboard from "../components/dashboard/Dashboard.jsx"
 
-document.addEventListener("DOMContentLoaded", () => {
+const renderDashboard = () => {
   const rootElement = document.getElementById("dashboard-react-root")
 
-  if (rootElement) {
-    const data = window.dashboardData || {}
+  if (!rootElement) return
 
-    const root = createRoot(rootElement)
-    root.render(<Dashboard {...data} />)
-  }
-})
+  if (rootElement.dataset.reactMounted === "true") return
+
+  rootElement.dataset.reactMounted = "true"
+
+  const data = window.dashboardData || {}
+  const root = createRoot(rootElement)
+  root.render(<Dashboard {...data} />)
+}
+
+document.addEventListener("turbo:load", renderDashboard)
+document.addEventListener("DOMContentLoaded", renderDashboard)


### PR DESCRIPTION
## 概要
ロゴをクリックしたときにdashboardが表示されないバグを見つけたので修正した

## 対応issue

## 変更内容
- DOMContentloardedにより、全体リロードしていたが、ロゴをクリックした場合はturboで部分リロードされていたため、発火しなかったことが原因。
- 初期化(createRoot)を2回しないように

# スクショ
変更前
[![Image from Gyazo](https://i.gyazo.com/06a9b87b22a9934210ea5f30ce9811c9.gif)](https://gyazo.com/06a9b87b22a9934210ea5f30ce9811c9)

変更後
[![Image from Gyazo](https://i.gyazo.com/0c0a5ab90adc381bef96174574dd36ff.gif)](https://gyazo.com/0c0a5ab90adc381bef96174574dd36ff)

## ここではやらないこと

- [ ]
