### PR TITLE
カレンダーページのレスポンシブデザイン採用

### DIFF
--- a/app/views/calendar/show.html.erb
+++ b/app/views/calendar/show.html.erb
@@ -118,6 +118,9 @@
             <div class="badge badge-xs" style="background-color: #F2EDA0; color: #1A1A1A;">満月</div>
             <div class="badge badge-xs" style="background-color: #EFD5F2; color: #1A1A1A;">下弦</div>
           </div>
+          <div>
+            <p class="text-base-content/70">※ 月の名前は、スマホでの横画面・PC・タブレットで表示されます</p>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 概要
スマホでカレンダーページを見たときに表示が崩れていたので、
月相バッジをスマホの縦画面では表示させないこととした。

## 対応issue
#193 

## 変更内容

- 月相バッジはスマホの縦画面では非表示、スマホ横画面・PC・タブレットでは表示させるように変えた
- 月の絵文字ｍのスマホでの表示を小さめにした

## スクショ（画面やログの一部）
スマホ縦画面
[![Image from Gyazo](https://i.gyazo.com/51ea6596c6e8b07423caea0ea1dc73bc.png)](https://gyazo.com/51ea6596c6e8b07423caea0ea1dc73bc)

スマホ横画面
[![Image from Gyazo](https://i.gyazo.com/84ef6513dd0571e17a7e70b258d1332c.gif)](https://gyazo.com/84ef6513dd0571e17a7e70b258d1332c)
