### PR TITLE
分析ページの表示のパフォーマンス改善をした

### DIFF
--- a/app/services/moon_api_service.rb
+++ b/app/services/moon_api_service.rb
@@ -134,29 +134,21 @@ class MoonApiService
 
   # グラフ用の月相を取得
   def self.fetch_moon_markers(start_date, end_date)
-    moon_markers = []
+    year = start_date.year
+    month = start_date.month
 
-    (start_date..end_date).each do |date|
-      result = fetch(date)
-      next if result.nil?
-
-      # strict_event を使用
-      if result[:event] == :full_moon
-        moon_markers << {
-          date: date.to_s,
-          type: "full_moon",
-          emoji: "🌕"
-        }
-      elsif result[:event] == :new_moon
-        moon_markers << {
-          date: date.to_s,
-          type: "new_moon",
-          emoji: "🌑"
-        }
+    moon_phases = MoonPhaseRepository.fetch_month(year, month)
+    moon_marks = []
+    # 満月と新月のときにアノテーションを表示させたい
+    moon_phases.each do |moon_phase|
+      event = detect_event(moon_phase.angle, STRICT_EVENT_TOLERANCE_DEGREES)
+      if event == :new_moon
+        moon_marks << { date: moon_phase.date.to_s, type: "new_moon", emoji: "🌑" }
+      elsif event == :full_moon
+        moon_marks << { date: moon_phase.date.to_s, type: "full_moon", emoji: "🌕️" }
       end
     end
-
-    moon_markers
+    moon_marks
   end
 
   def self.fetch_monthly_events_with_range(year, month)


### PR DESCRIPTION
## 概要
fetchさせていたところを、MoonPhaseRepositoryからデータを取ってくるように変えて
表示するスピードを上げた

## 対応issue
#276 

## 変更内容

- `MoonApiService`でアノテーションを表示させるためのメソッドでAPI叩いてたのを発見し、DBから引っ張ってくるように変えた

## スクショ（画面やログの一部）
分析ページにアクセスしたときログ（改善番）
```
tail -f log/development.log
  Rendered shared/_header.html.erb (Duration: 4.0ms | GC: 0.0ms)
  Rendered shared/_footer.html.erb (Duration: 0.1ms | GC: 0.0ms)
  Rendered layout layouts/application.html.erb (Duration: 24.2ms | GC: 0.0ms)
Completed 200 OK in 68ms (Views: 25.0ms | ActiveRecord: 1.1ms (5 queries, 0 cached) | GC: 0.0ms)


Started GET "/.well-known/appspecific/com.chrome.devtools.json" for 192.168.65.1 at 2026-03-11 13:22:41 +0000
  
ActionController::RoutingError (No route matches [GET] "/.well-known/appspecific/com.chrome.devtools.json"):
  
Started GET "/insights" for 192.168.65.1 at 2026-03-11 13:24:38 +0000
Processing by AnalysisController#show as HTML
  User Load (1.2ms)  SELECT "users".* FROM "users" WHERE "users"."id" = 3 LIMIT 1 /*action='show',application='TsukimeguruNote',controller='analysis'*/
  ↳ app/controllers/application_controller.rb:9:in `current_user'
  DailyNote Load (0.3ms)  SELECT "daily_notes".* FROM "daily_notes" WHERE "daily_notes"."user_id" = 3 AND "daily_notes"."date" BETWEEN '2026-03-01' AND '2026-03-31' /*action='show',application='TsukimeguruNote',controller='analysis'*/
  ↳ app/controllers/analysis_controller.rb:25:in `show'
  MoonPhase Pluck (0.3ms)  SELECT "moon_phases"."date" FROM "moon_phases" WHERE "moon_phases"."date" BETWEEN '2026-03-01' AND '2026-03-31' /*action='show',application='TsukimeguruNote',controller='analysis'*/
  ↳ app/services/moon_phase_repository.rb:8:in `fetch_month'
月相データをDBから取得: 2026年3月
  MoonPhase Load (0.3ms)  SELECT "moon_phases".* FROM "moon_phases" WHERE "moon_phases"."date" BETWEEN '2026-03-01' AND '2026-03-31' ORDER BY "moon_phases"."date" ASC /*action='show',application='TsukimeguruNote',controller='analysis'*/
  ↳ app/services/moon_api_service.rb:143:in `fetch_moon_markers'
  Rendering layout layouts/application.html.erb
  Rendering analysis/show.html.erb within layouts/application
  DailyNote Count (0.4ms)  SELECT COUNT(*) FROM "daily_notes" WHERE "daily_notes"."user_id" = 3 AND "daily_notes"."date" BETWEEN '2026-03-02' AND '2026-03-08' /*action='show',application='TsukimeguruNote',controller='analysis'*/
  ↳ app/presenters/weekly_summary_presenter.rb:13:in `count'
  Rendered analysis/_weekly_insight_card.html.erb (Duration: 2.2ms | GC: 0.0ms)
  Rendered analysis/show.html.erb within layouts/application (Duration: 4.9ms | GC: 0.0ms)
  Rendered shared/_loading.html.erb (Duration: 0.3ms | GC: 0.0ms)
  Rendered shared/_header.html.erb (Duration: 3.3ms | GC: 0.2ms)
  Rendered shared/_footer.html.erb (Duration: 0.3ms | GC: 0.0ms)
  Rendered layout layouts/application.html.erb (Duration: 12.2ms | GC: 0.2ms)
Completed 200 OK in 69ms (Views: 14.8ms | ActiveRecord: 6.4ms (5 queries, 0 cached) | GC: 1.3ms)
```
ちゃんとDBから取得できていることが確認できた。
表示もめっちゃ早くなったよ！

## ここではやらないこと

- [ ]

## 苦労したことなどあれば
- アノテーション表示のメソッドをMoonPhaseRepositoryでやるか、このサービスでやるか迷ったけど、これはビジネスロジックだからサービスクラスで書くように決めた（リポジトリクラスはデータ取得）
- デバッグしながら自分でちゃんと書けてよかった
